### PR TITLE
Add CRUD endpoints

### DIFF
--- a/backend/src/middleware/passportStrategies.ts
+++ b/backend/src/middleware/passportStrategies.ts
@@ -33,7 +33,7 @@ export const loginStrategy = new LocalStrategy(
   },
   async (email, password, done) => {
     try {
-      const user = await User.findOne({ where: { email } });
+      const user = await User.unscoped().findOne({ where: { email } });
 
       if (!user) {
         return done(makeError(errorMessages.AUTH_USER_NOT_FOUND, status.NOT_FOUND), null);

--- a/backend/src/models/classroom.ts
+++ b/backend/src/models/classroom.ts
@@ -29,7 +29,7 @@ Classroom.init(
       allowNull: false,
       validate: {
         min: 1,
-        msg: "Capacity can not be 0 or lower",
+        msg: 'Capacity can not be 0 or lower',
       },
     },
     createdAt: {
@@ -46,7 +46,7 @@ Classroom.init(
   {
     defaultScope: {
       attributes: {
-        exclude: [ 'id', 'updatedAt', ],
+        exclude: ['id', 'updatedAt'],
       },
     },
     sequelize,

--- a/backend/src/models/classroom.ts
+++ b/backend/src/models/classroom.ts
@@ -22,10 +22,15 @@ Classroom.init(
       type: DataTypes.CITEXT,
       allowNull: false,
       unique: true,
+      validate: { notEmpty: true },
     },
     capacity: {
       type: DataTypes.INTEGER,
       allowNull: false,
+      validate: {
+        min: 1,
+        msg: "Capacity can not be 0 or lower",
+      },
     },
     createdAt: {
       type: DataTypes.DATE,
@@ -39,6 +44,11 @@ Classroom.init(
     },
   },
   {
+    defaultScope: {
+      attributes: {
+        exclude: [ 'id', 'updatedAt', ],
+      },
+    },
     sequelize,
     modelName: 'Classroom',
     tableName: 'Classrooms',

--- a/backend/src/models/classroom.ts
+++ b/backend/src/models/classroom.ts
@@ -22,14 +22,16 @@ Classroom.init(
       type: DataTypes.CITEXT,
       allowNull: false,
       unique: true,
-      validate: { notEmpty: true },
+      validate: { notEmpty: { msg: 'Classroom name can not be empty' } },
     },
     capacity: {
       type: DataTypes.INTEGER,
       allowNull: false,
       validate: {
-        min: 1,
-        msg: 'Capacity can not be 0 or lower',
+        min: {
+          args: [1],
+          msg: 'Classroom capacity can not be 0 or lower',
+        },
       },
     },
     createdAt: {
@@ -46,7 +48,7 @@ Classroom.init(
   {
     defaultScope: {
       attributes: {
-        exclude: ['id', 'updatedAt'],
+        exclude: ['updatedAt'],
       },
     },
     sequelize,

--- a/backend/src/models/teacher.ts
+++ b/backend/src/models/teacher.ts
@@ -22,15 +22,27 @@ Teacher.init(
     firstName: {
       type: DataTypes.CITEXT,
       allowNull: false,
+      validate: {
+        len: [1, 100],
+        msg: "First name must be between 1 - 100 characters long",
+      },
     },
     lastName: {
       type: DataTypes.CITEXT,
       allowNull: false,
+      validate: {
+        len: [1, 100],
+        msg: "Last name must be between 1 - 100 characters long",
+      },
     },
     teacherCode: {
       type: DataTypes.CITEXT,
       allowNull: false,
       unique: true,
+      validate: {
+        notEmpty: true,
+        msg: "Teacher code can not be empty",
+      },
     },
     createdAt: {
       type: DataTypes.DATE,
@@ -44,6 +56,11 @@ Teacher.init(
     },
   },
   {
+    defaultScope: {
+      attributes: {
+        exclude: [ 'id', 'updatedAt', ],
+      },
+    },
     sequelize,
     modelName: 'Teacher',
     tableName: 'Teachers',

--- a/backend/src/models/teacher.ts
+++ b/backend/src/models/teacher.ts
@@ -23,16 +23,20 @@ Teacher.init(
       type: DataTypes.CITEXT,
       allowNull: false,
       validate: {
-        len: [1, 100],
-        msg: 'First name must be between 1 - 100 characters long',
+        len: {
+          args: [1, 100],
+          msg: 'First name must be between 1 - 100 characters long',
+        },
       },
     },
     lastName: {
       type: DataTypes.CITEXT,
       allowNull: false,
       validate: {
-        len: [1, 100],
-        msg: 'Last name must be between 1 - 100 characters long',
+        len: {
+          args: [1, 100],
+          msg: 'Last name must be between 1 - 100 characters long',
+        },
       },
     },
     teacherCode: {
@@ -40,8 +44,7 @@ Teacher.init(
       allowNull: false,
       unique: true,
       validate: {
-        notEmpty: true,
-        msg: 'Teacher code can not be empty',
+        notEmpty: { msg: 'Teacher code can not be empty' },
       },
     },
     createdAt: {
@@ -58,7 +61,7 @@ Teacher.init(
   {
     defaultScope: {
       attributes: {
-        exclude: ['id', 'updatedAt'],
+        exclude: ['updatedAt'],
       },
     },
     sequelize,

--- a/backend/src/models/teacher.ts
+++ b/backend/src/models/teacher.ts
@@ -24,7 +24,7 @@ Teacher.init(
       allowNull: false,
       validate: {
         len: [1, 100],
-        msg: "First name must be between 1 - 100 characters long",
+        msg: 'First name must be between 1 - 100 characters long',
       },
     },
     lastName: {
@@ -32,7 +32,7 @@ Teacher.init(
       allowNull: false,
       validate: {
         len: [1, 100],
-        msg: "Last name must be between 1 - 100 characters long",
+        msg: 'Last name must be between 1 - 100 characters long',
       },
     },
     teacherCode: {
@@ -41,7 +41,7 @@ Teacher.init(
       unique: true,
       validate: {
         notEmpty: true,
-        msg: "Teacher code can not be empty",
+        msg: 'Teacher code can not be empty',
       },
     },
     createdAt: {
@@ -58,7 +58,7 @@ Teacher.init(
   {
     defaultScope: {
       attributes: {
-        exclude: [ 'id', 'updatedAt', ],
+        exclude: ['id', 'updatedAt'],
       },
     },
     sequelize,

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -39,14 +39,14 @@ User.init(
       type: DataTypes.CITEXT,
       allowNull: false,
       unique: true,
-      validate: { isEmail: { msg: "Invalid Email format" }},
+      validate: { isEmail: { msg: 'Invalid Email format' } },
     },
     password: {
       type: DataTypes.STRING,
       allowNull: false,
       validate: {
-        notEmpty: { msg: 'Can not be empty'},
-        len: [8,100],
+        notEmpty: { msg: 'Can not be empty' },
+        len: [8, 100],
       },
     },
     createdAt: {
@@ -66,13 +66,12 @@ User.init(
         user.password = await user.encryptPassword(user.password);
       },
       beforeUpdate: async (user: User) => {
-        if(user.changed('password'))
-          user.password = await user.encryptPassword(user.password);
-      }
+        if (user.changed('password')) user.password = await user.encryptPassword(user.password);
+      },
     },
     defaultScope: {
       attributes: {
-        exclude: ['id', 'password', 'updatedAt' ],
+        exclude: ['id', 'password', 'updatedAt'],
       },
     },
     sequelize,

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -11,13 +11,12 @@ class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  async isValidPassword(password: string) {
-    return await bcrypt.compare(password, this.password);
+  isValidPassword(password: string) {
+    return bcrypt.compare(password, this.password);
   }
 
-  async encryptPassword(password: string) {
-    const hash = await bcrypt.hash(password, parseInt(process.env.SALT_ROUNDS || '10'));
-    return hash;
+  encryptPassword(password: string) {
+    return bcrypt.hash(password, parseInt(process.env.SALT_ROUNDS || '10'));
   }
 
   generateToken() {

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -15,8 +15,13 @@ class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
     return bcrypt.compare(password, this.password);
   }
 
+  async encryptPassword(password: string) {
+    const hash = await bcrypt.hash(password, parseInt(process.env.SALT_ROUNDS || '10'));
+    return hash;
+  }
+
   generateToken() {
-    const body = { _id: this.id, email: this.email };
+    const body = { id: this.id, email: this.email };
     const token = jwt.sign({ user: body }, process.env.JWT_SECRET_KEY || '');
     return token;
   }
@@ -34,10 +39,15 @@ User.init(
       type: DataTypes.CITEXT,
       allowNull: false,
       unique: true,
+      validate: { isEmail: { msg: "Invalid Email format" }},
     },
     password: {
       type: DataTypes.STRING,
       allowNull: false,
+      validate: {
+        notEmpty: { msg: 'Can not be empty'},
+        len: [8,100],
+      },
     },
     createdAt: {
       type: DataTypes.DATE,
@@ -53,8 +63,16 @@ User.init(
   {
     hooks: {
       beforeCreate: async (user: User) => {
-        const hash = await bcrypt.hash(user.password, parseInt(process.env.SALT_ROUNDS || '10'));
-        user.password = hash;
+        user.password = await user.encryptPassword(user.password);
+      },
+      beforeUpdate: async (user: User) => {
+        if(user.changed('password'))
+          user.password = await user.encryptPassword(user.password);
+      }
+    },
+    defaultScope: {
+      attributes: {
+        exclude: ['id', 'password', 'updatedAt' ],
       },
     },
     sequelize,

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -69,7 +69,9 @@ User.init(
         user.password = await user.encryptPassword(user.password);
       },
       beforeUpdate: async (user: User) => {
-        if (user.changed('password')) user.password = await user.encryptPassword(user.password);
+        if (user.changed('password')) {
+          user.password = await user.encryptPassword(user.password);
+        }
       },
     },
     defaultScope: {

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -11,8 +11,8 @@ class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  isValidPassword(password: string) {
-    return bcrypt.compare(password, this.password);
+  async isValidPassword(password: string) {
+    return await bcrypt.compare(password, this.password);
   }
 
   async encryptPassword(password: string) {
@@ -39,14 +39,17 @@ User.init(
       type: DataTypes.CITEXT,
       allowNull: false,
       unique: true,
-      validate: { isEmail: { msg: 'Invalid Email format' } },
+      validate: { isEmail: { msg: 'Invalid Email format.' } },
     },
     password: {
       type: DataTypes.STRING,
       allowNull: false,
       validate: {
-        notEmpty: { msg: 'Can not be empty' },
-        len: [8, 100],
+        notEmpty: { msg: 'Password can not be empty. Please enter your password.' },
+        len: {
+          args: [8, 128],
+          msg: 'Password length is either too short or too long. It must be from 8 to 128 characters long.',
+        },
       },
     },
     createdAt: {

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -21,8 +21,7 @@ class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
 
   generateToken() {
     const body = { id: this.id, email: this.email };
-    const token = jwt.sign({ user: body }, process.env.JWT_SECRET_KEY || '');
-    return token;
+    return jwt.sign({ user: body }, process.env.JWT_SECRET_KEY || '');
   }
 }
 

--- a/backend/src/routes/classroom.ts
+++ b/backend/src/routes/classroom.ts
@@ -5,25 +5,23 @@ import { NOT_FOUND } from 'http-status';
 
 const router = Router();
 
-router.get('/', async (req: Request, res: Response, next: NextFunction) => {
-  await Classroom.findAll()
+router.get('/', (req: Request, res: Response, next: NextFunction) => {
+  Classroom.findAll()
     .then(classrooms => res.json(classrooms))
     .catch(error => next(error));
 });
 
-router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
-  await Classroom.findByPk(req.params.id)
+router.get('/:id', (req: Request, res: Response, next: NextFunction) => {
+  Classroom.findByPk(req.params.id)
     .then(classroom => {
-      if (!classroom) {
-        return next(makeError('Classroom with that id not found.', NOT_FOUND));
-      }
-      res.json(classroom);
+      if (classroom) return res.json(classroom);
+      return next(makeError('Classroom with that id not found.', NOT_FOUND));
     })
     .catch(error => next(error));
 });
 
-router.post('/', async (req, res: Response, next: NextFunction) => {
-  await Classroom.create({
+router.post('/', (req, res: Response, next: NextFunction) => {
+  Classroom.create({
     name: req.body.name,
     capacity: req.body.capacity,
   })
@@ -31,8 +29,8 @@ router.post('/', async (req, res: Response, next: NextFunction) => {
     .catch(error => next(error));
 });
 
-router.put('/:id', async (req: Request, res: Response, next: NextFunction) => {
-  await Classroom.update(
+router.put('/:id', (req: Request, res: Response, next: NextFunction) => {
+  Classroom.update(
     {
       name: req.body.name,
       capacity: req.body.capacity,
@@ -40,21 +38,17 @@ router.put('/:id', async (req: Request, res: Response, next: NextFunction) => {
     { where: { id: req.params.id } },
   )
     .then(async results => {
-      if (!results[0]) {
-        return next(makeError('Classroom with that id not found.', NOT_FOUND));
-      }
-      res.json(await Classroom.findByPk(req.params.id));
+      if (results[0]) return res.json(await Classroom.findByPk(req.params.id));
+      return next(makeError('Classroom with that id not found.', NOT_FOUND));
     })
     .catch(error => next(error));
 });
 
 router.delete('/:id', async (req: Request, res: Response, next: NextFunction) => {
-  await Classroom.destroy({ where: { id: req.params.id } })
+  Classroom.destroy({ where: { id: req.params.id } })
     .then(result => {
-      if (!result) {
-        return next(makeError('Classroom with id not found.', NOT_FOUND));
-      }
-      res.json({ message: 'Classroom deleted successfully.' });
+      if (result) return res.json({ message: 'Classroom deleted successfully.' });
+      return next(makeError('Classroom with id not found.', NOT_FOUND));
     })
     .catch(error => next(error));
 });

--- a/backend/src/routes/classroom.ts
+++ b/backend/src/routes/classroom.ts
@@ -1,62 +1,62 @@
-import { BAD_REQUEST, INTERNAL_SERVER_ERROR, NO_CONTENT } from 'http-status';
-import { Request, Response, Router } from 'express';
+import { NextFunction, Request, Response, Router } from 'express';
 import Classroom from 'models/classroom';
+import { makeError } from 'helpers/error';
+import { NOT_FOUND } from 'http-status';
 
 const router = Router();
 
-router.get('/', async (req: Request, res: Response) => {
-  const classrooms = await Classroom.findAll();
-
-  res.json(classrooms);
+router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  await Classroom.findAll()
+    .then(classrooms => res.json(classrooms))
+    .catch(next);
 });
 
-router.post('/', async (req: Request, res: Response) => {
-  const { name, capacity } = req.body as Classroom;
-
-  if (name === null || capacity < 1) return res.status(BAD_REQUEST).json({ message: 'Bad Request' });
-
-  const classroom = await Classroom.create({
-    name,
-    capacity,
-  });
-
-  if (classroom === null) return res.status(INTERNAL_SERVER_ERROR).json({ message: 'Internal Server Error' });
-
-  return res.json(classroom);
+router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  await Classroom.findByPk(req.params.id)
+    .then(classroom => {
+      if (!classroom) {
+        return next(makeError('Classroom with that id not found.', NOT_FOUND));
+      }
+      res.json(classroom);
+    })
+    .catch(next);
 });
 
-router.put('/:id', async (req: Request, res: Response) => {
-  const { name, capacity } = req.body as Classroom;
-  const { id } = req.params;
+router.post('/', async (req, res: Response, next: NextFunction) => {
+  await Classroom.create({
+    name: req.body.name,
+    capacity: req.body.capacity,
+  })
+    .then(classroom => res.json(classroom))
+    .catch(next);
+});
 
-  if (name === null || capacity < 1) return res.status(BAD_REQUEST).json({ message: 'Bad Request' });
-
-  const classroom = await Classroom.update(
+router.put('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  await Classroom.update(
     {
-      name,
-      capacity,
+      name: req.body.name,
+      capacity: req.body.capacity,
     },
-    {
-      where: { id },
-    },
-  );
-
-  if (classroom === null) return res.status(INTERNAL_SERVER_ERROR).json({ message: 'Internal Server Error' });
-
-  return res.json(classroom);
+    { where: { id: req.params.id } },
+  )
+    .then(async results => {
+      if (!results[0]) {
+        return next(makeError('Classroom with that id not found.', NOT_FOUND));
+      }
+      res.json(await Classroom.findByPk(req.params.id));
+    })
+    .catch(error => next(error));
 });
 
-router.delete('/:id', async (req: Request, res: Response) => {
-  const { id } = req.params;
-  // const classroom = await Classroom.findByPk(id);
-
-  // if (classroom === null)
-  //   return res.status(httpStatus.NOT_FOUND).json({ message: "Not Found"});
-
-  // await classroom.destroy();
-
-  // return res.json(id);
-  return Classroom.destroy({ where: { id } }).then(() => res.sendStatus(NO_CONTENT));
+router.delete('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  await Classroom.destroy({ where: { id: req.params.id } })
+    .then(result => {
+      if (!result) {
+        return next(makeError('Classroom with id not found.', NOT_FOUND));
+      }
+      res.json({ message: 'Classroom deleted successfully.' });
+    })
+    .catch(error => next(error));
 });
 
 export default router;

--- a/backend/src/routes/classroom.ts
+++ b/backend/src/routes/classroom.ts
@@ -8,7 +8,7 @@ const router = Router();
 router.get('/', async (req: Request, res: Response, next: NextFunction) => {
   await Classroom.findAll()
     .then(classrooms => res.json(classrooms))
-    .catch(next);
+    .catch(error => next(error));
 });
 
 router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
@@ -19,7 +19,7 @@ router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
       }
       res.json(classroom);
     })
-    .catch(next);
+    .catch(error => next(error));
 });
 
 router.post('/', async (req, res: Response, next: NextFunction) => {
@@ -28,7 +28,7 @@ router.post('/', async (req, res: Response, next: NextFunction) => {
     capacity: req.body.capacity,
   })
     .then(classroom => res.json(classroom))
-    .catch(next);
+    .catch(error => next(error));
 });
 
 router.put('/:id', async (req: Request, res: Response, next: NextFunction) => {

--- a/backend/src/routes/classroom.ts
+++ b/backend/src/routes/classroom.ts
@@ -1,3 +1,4 @@
+import { BAD_REQUEST, INTERNAL_SERVER_ERROR, NO_CONTENT } from 'http-status';
 import { Request, Response, Router } from 'express';
 import Classroom from 'models/classroom';
 
@@ -7,6 +8,55 @@ router.get('/', async (req: Request, res: Response) => {
   const classrooms = await Classroom.findAll();
 
   res.json(classrooms);
+});
+
+router.post('/', async (req: Request, res: Response) => {
+  const { name, capacity } = req.body as Classroom;
+
+  if (name === null || capacity < 1) return res.status(BAD_REQUEST).json({ message: 'Bad Request' });
+
+  const classroom = await Classroom.create({
+    name,
+    capacity,
+  });
+
+  if (classroom === null) return res.status(INTERNAL_SERVER_ERROR).json({ message: 'Internal Server Error' });
+
+  return res.json(classroom);
+});
+
+router.put('/:id', async (req: Request, res: Response) => {
+  const { name, capacity } = req.body as Classroom;
+  const { id } = req.params;
+
+  if (name === null || capacity < 1) return res.status(BAD_REQUEST).json({ message: 'Bad Request' });
+
+  const classroom = await Classroom.update(
+    {
+      name,
+      capacity,
+    },
+    {
+      where: { id },
+    },
+  );
+
+  if (classroom === null) return res.status(INTERNAL_SERVER_ERROR).json({ message: 'Internal Server Error' });
+
+  return res.json(classroom);
+});
+
+router.delete('/:id', async (req: Request, res: Response) => {
+  const { id } = req.params;
+  // const classroom = await Classroom.findByPk(id);
+
+  // if (classroom === null)
+  //   return res.status(httpStatus.NOT_FOUND).json({ message: "Not Found"});
+
+  // await classroom.destroy();
+
+  // return res.json(id);
+  return Classroom.destroy({ where: { id } }).then(() => res.sendStatus(NO_CONTENT));
 });
 
 export default router;

--- a/backend/src/routes/classroom.ts
+++ b/backend/src/routes/classroom.ts
@@ -35,10 +35,15 @@ router.put('/:id', (req: Request, res: Response, next: NextFunction) => {
       name: req.body.name,
       capacity: req.body.capacity,
     },
-    { where: { id: req.params.id } },
+    {
+      where: { id: req.params.id },
+      returning: true,
+    },
   )
-    .then(async results => {
-      if (results[0]) return res.json(await Classroom.findByPk(req.params.id));
+    .then(results => {
+      // result = [x] or [x, y] => [x] if you're not using Postgres OR [x, y] if you are using Postgres
+      // The first element x is always the number of affected rows, while the second element y is the actual affected rows
+      if (results[1][0]) return res.json(results[1][0]);
       return next(makeError('Classroom with that id not found.', NOT_FOUND));
     })
     .catch(error => next(error));

--- a/backend/src/routes/teacher.ts
+++ b/backend/src/routes/teacher.ts
@@ -5,25 +5,23 @@ import Teacher from 'models/teacher';
 
 const router = Router();
 
-router.get('/', async (req: Request, res: Response, next: NextFunction) => {
-  await Teacher.findAll()
+router.get('/', (req: Request, res: Response, next: NextFunction) => {
+  Teacher.findAll()
     .then(teachers => res.json(teachers))
     .catch(error => next(error));
 });
 
-router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
-  await Teacher.findByPk(req.params.id)
+router.get('/:id', (req: Request, res: Response, next: NextFunction) => {
+  Teacher.findByPk(req.params.id)
     .then(teacher => {
-      if (!teacher) {
-        return next(makeError('Teacher with that id not found.', NOT_FOUND));
-      }
-      res.json(teacher);
+      if (teacher) return res.json(teacher);
+      return next(makeError('Teacher with that id not found.', NOT_FOUND));
     })
     .catch(error => next(error));
 });
 
-router.post('/', async (req: Request, res: Response, next: NextFunction) => {
-  await Teacher.create({
+router.post('/', (req: Request, res: Response, next: NextFunction) => {
+  Teacher.create({
     firstName: req.body.firstName,
     lastName: req.body.lastName,
     teacherCode: req.body.teacherCode,
@@ -32,8 +30,8 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
     .catch(error => next(error));
 });
 
-router.put('/:id', async (req: Request, res: Response, next: NextFunction) => {
-  await Teacher.update(
+router.put('/:id', (req: Request, res: Response, next: NextFunction) => {
+  Teacher.update(
     {
       firstName: req.body.firstName,
       lastName: req.body.lastName,
@@ -42,21 +40,17 @@ router.put('/:id', async (req: Request, res: Response, next: NextFunction) => {
     { where: { id: req.params.id } },
   )
     .then(async results => {
-      if (!results[0]) {
-        return next(makeError('Teacher with that id not found.', NOT_FOUND));
-      }
-      res.json(await Teacher.findByPk(req.params.id));
+      if (results[0]) return res.json(await Teacher.findByPk(req.params.id));
+      return next(makeError('Teacher with that id not found.', NOT_FOUND));
     })
     .catch(error => next(error));
 });
 
-router.delete('/:id', async (req: Request, res: Response, next: NextFunction) => {
-  await Teacher.destroy({ where: { id: req.params.id } })
+router.delete('/:id', (req: Request, res: Response, next: NextFunction) => {
+  Teacher.destroy({ where: { id: req.params.id } })
     .then(result => {
-      if (!result) {
-        return next(makeError('Teacher with that id not found.', NOT_FOUND));
-      }
-      res.json({ message: 'Teacher deleted successfully.' });
+      if (result) return res.json({ message: 'Teacher deleted successfully.' });
+      return next(makeError('Teacher with that id not found.', NOT_FOUND));
     })
     .catch(error => next(error));
 });

--- a/backend/src/routes/teacher.ts
+++ b/backend/src/routes/teacher.ts
@@ -1,4 +1,5 @@
 import { Request, Response, Router } from 'express';
+import httpStatus from 'http-status';
 import Teacher from 'models/teacher';
 
 const router = Router();
@@ -6,7 +7,58 @@ const router = Router();
 router.get('/', async (req: Request, res: Response) => {
   const teachers = await Teacher.findAll();
 
-  res.json(teachers);
+  return res.json(teachers);
+});
+
+router.post('/', async (req: Request, res: Response) => {
+  const { firstName, lastName, teacherCode } = req.body as Teacher;
+
+  if (firstName === null || lastName === null || teacherCode === null)
+    return res.status(httpStatus.BAD_REQUEST).json({ message: 'Bad Request' });
+
+  const teacher = await Teacher.create({
+    firstName,
+    lastName,
+    teacherCode,
+  });
+
+  if (teacher === null) return res.status(httpStatus.INTERNAL_SERVER_ERROR).json({ message: 'Internal Server Error' });
+
+  return res.json(teacher);
+});
+
+router.put('/:id', async (req: Request, res: Response) => {
+  const { firstName, lastName, teacherCode } = req.body as Teacher;
+  const { id } = req.params;
+
+  if (firstName === null || lastName === null || teacherCode === null)
+    return res.status(httpStatus.BAD_REQUEST).json({ message: 'Bad Request' });
+
+  const teacher = await Teacher.update(
+    {
+      firstName,
+      lastName,
+      teacherCode,
+    },
+    {
+      where: { id },
+    },
+  );
+
+  if (teacher === null) return res.status(httpStatus.INTERNAL_SERVER_ERROR).json({ message: 'Internal Server Error' });
+
+  return res.json(teacher);
+});
+
+router.delete('/:id', async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const teacher = await Teacher.findByPk(id);
+
+  if (teacher === null) return res.status(httpStatus.NOT_FOUND).json({ message: 'Not Found' });
+
+  teacher.destroy();
+
+  return res.json(id);
 });
 
 export default router;

--- a/backend/src/routes/teacher.ts
+++ b/backend/src/routes/teacher.ts
@@ -37,10 +37,15 @@ router.put('/:id', (req: Request, res: Response, next: NextFunction) => {
       lastName: req.body.lastName,
       teacherCode: req.body.teacherCode,
     },
-    { where: { id: req.params.id } },
+    {
+      where: { id: req.params.id },
+      returning: true,
+    },
   )
-    .then(async results => {
-      if (results[0]) return res.json(await Teacher.findByPk(req.params.id));
+    .then(results => {
+      // result = [x] or [x, y] => [x] if you're not using Postgres OR [x, y] if you are using Postgres
+      // The first element x is always the number of affected rows, while the second element y is the actual affected rows
+      if (results[1][0]) return res.json(results[1][0]);
       return next(makeError('Teacher with that id not found.', NOT_FOUND));
     })
     .catch(error => next(error));

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -32,14 +32,19 @@ router.delete('/profile', async (req: Request, res: Response, next: NextFunction
 });
 
 router.put('/profile/password', async (req: Request, res: Response, next: NextFunction) => {
-  const { id } = req.user as User;
   const { currentPassword, newPassword } = req.body;
 
   if (currentPassword === newPassword) {
     return makeError('New password is same as old password. Please, enter different password.', BAD_REQUEST);
   }
 
-  await User.update({ password: newPassword }, { where: { id }, individualHooks: true })
+  await User.update(
+    { password: newPassword },
+    {
+      where: { id: (req.user as User).id },
+      individualHooks: true,
+    },
+  )
     .then(() => res.json({ message: 'Password changed successfully' }))
     .catch(error => next(error));
 });

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -1,12 +1,74 @@
-import { Request, Response, Router } from 'express';
+import { BAD_REQUEST, NO_CONTENT, NOT_FOUND } from 'http-status';
+import { NextFunction, Request, Response, Router } from 'express';
+import { makeError } from 'helpers/error';
 import User from 'models/user';
 
 const router = Router();
 
-router.get('/', async (req: Request, res: Response) => {
-  const users = await User.findAll();
+router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const users = await User.findAll();
 
-  res.json(users);
+    return res.json(users);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { id } = req.user as User;
+    const { email } = req.body;
+
+    await User.update({ email }, { where: { id } });
+    const user = await User.findByPk(id);
+
+    return res.json(user);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/profile', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { id } = req.user as User;
+    const user = await User.findByPk(id);
+
+    if (user === null) return makeError('Not Found', NOT_FOUND);
+
+    return res.json(user);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete('/profile', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { id } = req.user as User;
+    const user = await User.findByPk(id);
+
+    if (user === null) return makeError('Not Found', NOT_FOUND);
+
+    await user.destroy();
+
+    return res.status(NO_CONTENT).json();
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/profile/password', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { id } = req.user as User;
+    const { currentPassword, newPassword } = req.body;
+    const user = await User.update({ password: newPassword }, { where: { id } });
+
+    if (currentPassword === newPassword || user === null) return makeError('Bad Request', BAD_REQUEST);
+
+    return res.json(user);
+  } catch (error) {
+    next(error);
+  }
 });
 
 export default router;

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -32,12 +32,14 @@ router.delete('/profile', async (req: Request, res: Response, next: NextFunction
 });
 
 router.put('/profile/password', async (req: Request, res: Response, next: NextFunction) => {
+  const { id } = req.user as User;
   const { currentPassword, newPassword } = req.body;
 
-  if (currentPassword === newPassword)
+  if (currentPassword === newPassword) {
     return makeError('New password is same as old password. Please, enter different password.', BAD_REQUEST);
+  }
 
-  await User.update({ password: newPassword }, { where: { id: (req.user as User).id }, individualHooks: true })
+  await User.update({ password: newPassword }, { where: { id }, individualHooks: true })
     .then(() => res.json({ message: 'Password changed successfully' }))
     .catch(error => next(error));
 });

--- a/backend/src/routes/user.ts
+++ b/backend/src/routes/user.ts
@@ -5,40 +5,39 @@ import User from 'models/user';
 
 const router = Router();
 
-router.get('/', async (req: Request, res: Response, next: NextFunction) => {
-  await User.findAll()
+router.get('/', (req: Request, res: Response, next: NextFunction) => {
+  User.findAll()
     .then(users => res.json(users))
     .catch(error => next(error));
 });
 
-router.put('/', async (req: Request, res: Response, next: NextFunction) => {
+router.put('/', (req: Request, res: Response, next: NextFunction) => {
   const { id } = req.user as User;
 
-  await User.update({ email: req.body.email }, { where: { id } })
-    .then(async () => res.json(await User.findByPk(id)))
+  User.update({ email: req.body.email }, { where: { id } })
+    .then(() => res.json(User.findByPk(id)))
     .catch(error => next(error));
 });
 
-router.get('/profile', async (req: Request, res: Response, next: NextFunction) => {
-  await User.findByPk((req.user as User).id)
+router.get('/profile', (req: Request, res: Response, next: NextFunction) => {
+  User.findByPk((req.user as User).id)
     .then(user => res.json(user))
     .catch(error => next(error));
 });
 
-router.delete('/profile', async (req: Request, res: Response, next: NextFunction) => {
-  await User.destroy({ where: { id: (req.user as User).id } })
+router.delete('/profile', (req: Request, res: Response, next: NextFunction) => {
+  User.destroy({ where: { id: (req.user as User).id } })
     .then(() => res.json({ message: 'Deleted successfully' }))
     .catch(error => next(error));
 });
 
-router.put('/profile/password', async (req: Request, res: Response, next: NextFunction) => {
+router.put('/profile/password', (req: Request, res: Response, next: NextFunction) => {
   const { currentPassword, newPassword } = req.body;
 
-  if (currentPassword === newPassword) {
+  if (currentPassword === newPassword)
     return makeError('New password is same as old password. Please, enter different password.', BAD_REQUEST);
-  }
 
-  await User.update(
+  User.update(
     { password: newPassword },
     {
       where: { id: (req.user as User).id },


### PR DESCRIPTION
This PR adds CRUD endpoints for the models that we have so far (user, classroom, teacher). Response pattern I tried to follow is that create, read and update requests return requested or modified data and delete requests only return success message. This will be added additionally as summary in code with expected request format. We also plan to add global error messages in the future. Furthermore, default scope and validation is added directly to the models, so validation checks are performed in the Sequelize level. 