### PR TITLE
Eslint warn relative paths

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -4,4 +4,8 @@ module.exports = {
   parserOptions: {
     sourceType: 'module',
   },
+  plugins: ['no-relative-import-paths'],
+  rules: {
+    'no-relative-import-paths/no-relative-import-paths': ['warn', { allowSameFolder: true }],
+  },
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-n": "^15.2.4",
+    "eslint-plugin-no-relative-import-paths": "^1.4.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.0.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -914,6 +914,11 @@ eslint-plugin-n@^15.2.4:
     resolve "^1.10.1"
     semver "^7.3.7"
 
+eslint-plugin-no-relative-import-paths@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.4.0.tgz#59489ebc19688d1398bfe53d3ad320b3ed42ca17"
+  integrity sha512-J/ok26KqJM+20VsxNEcHc9kyW0dcFHBlihOO5FFv/GQqwcW+G1UngbHLpnPAdOQ1dJg5Ljk/40csqfZ3mnneUw==
+
 eslint-plugin-node@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"


### PR DESCRIPTION
This PR adds rule to ESLint that warns when relative paths like `../components/Component.vue` instead of `@/components/Component.vue` are used.